### PR TITLE
Add compatibility for most GoPro cameras

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,39 @@
 # GoPro remote for Garmin watch
-A ConnectIQ widget to control your GoPro from your wrist. Uses the [Open GoPro Bluetooth Low Energy API](https://gopro.github.io/OpenGoPro/ble_2_0) and the [Garmin ConnectIQ SDK](https://developer.garmin.com/connect-iq/overview/).
+A ConnectIQ widget to control your GoPro from your wrist. It uses the [Open GoPro Bluetooth Low Energy API](https://gopro.github.io/OpenGoPro/ble_2_0) and the [Garmin ConnectIQ SDK](https://developer.garmin.com/connect-iq/overview/).
 
-The widget is now supporting every mainstream Garmin watch with API level 2.4.0 and above. However it is designed to be used specifically with a GoPro HERO11 as the capabilities are hardcoded in the app.
+The widget is now supporting every mainstream Garmin watch with API level 2.4.0 and above. Since v2.0, it also works with every GoPro camera supporting the Open GoPro API (HERO9+) except the newer GoPro HERO 13 Black due to API changes.
 
-Must be used in pair with the [Android companion app](https://github.com/ad220/gopro-remote-companion-android) as a bridge to communicate with the GoPro.
+This app must be used in pair with the [Android companion app](https://github.com/ad220/gopro-remote-companion-android) as a bridge to communicate with the GoPro.
 
-Please note that the app is still under development and while this should be stable enough to play with, it may still encounter a few bugs.
+Please note that this app was mainly developed for personal use, it should now be stable enough but you may still encounter a few bugs.
 
 ## Features
-- allows a Garmin watch to control a GoPro[*](#disclaimer)
+- allows a Garmin watch to control a GoPro HERO 9-12
 - press shutter (start and stop video)
 - add hilight when recording
 - change camera settings manually
 - change camera settings with customizable presets
 
 
-### Planned
-- achieve full support for all Open GoPro cameras (see [*](#disclaimer))
+### Planned [(*)](#disclaimer)
 - add photo support
 - add hypersmooth + most of toggables states
 - better info and error pop-ups message
+- add direct BLE connection to the GoPro
 
 ## Installation
 The widget is available on the [Garmin Connect IQ store](https://apps.garmin.com/apps/f9e09224-1c60-4e94-a616-f9ef10932fdf). You can install it directly from your Garmin Connect app on your smartphone.
 
 You can also build the widget for your specific device with the Garmin SDK and the VSCode extension. Then, plug your watch to the computer with the USB cable in mass storage mode, and copy the generated `.prg` file to the `/GARMIN/APPS` folder on your device.
 
-Alternatively you can use the release provided on GitHub.
+Alternatively you can use the release provided on GitHub. Make sure you are using a version matching the one of the companion app though.
 
 ## How to use it
 Once the companion app is [installed](https://github.com/ad220/gopro-remote-companion-android#Installation), started and configured on your Android smartphone, the widget is ready to connect to the GoPro.
 
 Press the connect button on the main screen of the widget and wait for the phone to achieve connection with your camera. Once it's done, you should see the remote screen with the shutter button and the GoPro current settings.
 
-Selecting the settings button will allow you to apply a defined preset, edit one of these or manually change camera's settings.
+Selecting the settings button will allow you to apply a defined preset, manually change camera settings or save the current applied settings as a preset.
 
 ## Screenshots gallery
 ![](documentation/screenshots/connect.png)
@@ -43,4 +43,4 @@ Selecting the settings button will allow you to apply a defined preset, edit one
 ![](documentation/screenshots/presets.png)
 
 ## Disclaimer
-(*): The GoPro settings capabilities are hardcoded in the widget according to the GoPro HERO11 Black Mini's [user manual](https://gopro.com/help/productmanuals). Therefore, it may not be able to use the full capabilities of all the other GoPros 
+(*): The planned features are not guaranteed to be implemented. The development of this app is done on my free time, and with the compatibility additions done in v2, I don't feel like continuing this anymore (at least for now). If you want to help, feel free to contribute to the project.

--- a/resources-fre/strings/strings.xml
+++ b/resources-fre/strings/strings.xml
@@ -10,11 +10,11 @@
     <string id="Sport">Sport</string>
     <string id="Eco">Éco</string>
     <string id="Manually">Paramétrage\n manuel</string>
-    <string id="EditP7">Editer les\npréréglages</string>
+    <string id="SaveP7">Sauvegarder\ncomme préréglage</string>
 
     <!-- Menus -->
     <string id="Settings">Paramètres</string>
-    <string id="Presets">Éditer un\npréréglage</string>
+    <string id="Presets">Choix du\npréréglage</string>
     
     <!-- Paramètres -->
     <string id="Resolution">Résolution</string>

--- a/resources-fre/strings/strings.xml
+++ b/resources-fre/strings/strings.xml
@@ -10,11 +10,11 @@
     <string id="Sport">Sport</string>
     <string id="Eco">Éco</string>
     <string id="Manually">Paramétrage\n manuel</string>
-    <string id="SaveP7">Sauvegarder\ncomme préréglage</string>
+    <string id="SaveP7">Sauvegarder\ncomme mode</string>
 
     <!-- Menus -->
     <string id="Settings">Paramètres</string>
-    <string id="Presets">Choix du\npréréglage</string>
+    <string id="Presets">Choix du\nmode</string>
     
     <!-- Paramètres -->
     <string id="Resolution">Résolution</string>
@@ -37,4 +37,5 @@
     <string id="_LARGE">Large</string>
     <string id="_LINEAR">Linéaire</string>
     <string id="_LINEARLOCK">Linéaire + VH</string>
+    <string id="_NARROW">Étroit</string>
 </strings>

--- a/resources/fonts/fonts.xml
+++ b/resources/fonts/fonts.xml
@@ -1,6 +1,6 @@
 <fonts>
-    <font id="Tiny" filename="tiny.fnt" antialias="true" filter=" '+.0123456789:ACEFGHIKLMNOPRSTUVXabcdefghijlmnopqrstuwxyÉàèé@"/>
-    <font id="Small" filename="small.fnt" antialias="true" filter=" '+.0123456789:ACEFGHIKLMNOPRSTUVXabcdefghijlmnopqrstuwxyÉàèé@!"/>
+    <font id="Tiny" filename="tiny.fnt" antialias="true" filter=" '+.0123456789:ACEFGHIKLMNOPRSTUVXabcdefghijlmnopqrstuvwxyÉàèé@"/>
+    <font id="Small" filename="small.fnt" antialias="true" filter=" '+.0123456789:ACEFGHIKLMNOPRSTUVXabcdefghijlmnopqrstuvwxyÉàèé@!"/>
     <font id="Medium" filename="medium.fnt" antialias="true" filter=" '+.0123456789:ACEFGHIKLMNOPRSTVXabcdefgijlmnopqrstuwyÉèé@!"/>
-    <font id="Large" filename="large.fnt" antialias="true" filter=" '+.0123456789:ACEFGHIKLMNOPRSTVXabcdefgijlmnopqrstuwyÉèé"/>
+    <font id="Large" filename="large.fnt" antialias="true" filter=" '+.0123456789:ACEFGHIKLMNOPRSTVXabcdefghijlmnopqrstuwxyÉèé"/>
 </fonts>

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -40,16 +40,20 @@
     <string id="_LARGE">Large</string>
     <string id="_LINEAR">Linear</string>
     <string id="_LINEARLOCK">Linear + HL</string>
+    <string id="_NARROW">Narrow</string>
 
     <!-- Resolutions -->
-    <string id="_5K" translatable="false">5.3K</string>
+    <string id="_5K3" translatable="false">5.3K</string>
+    <string id="_5K" translatable="false">5K</string>
     <string id="_4K" translatable="false">4K</string>
     <string id="_2K7" translatable="false">2.7K</string>
+    <string id="_1440" translatable="false">1440p</string>
     <string id="_1080" translatable="false">1080p</string>
 
     <!-- Aspect Ratios -->
     <string id="_8R7" translatable="false">8:7</string>
     <string id="_4R3" translatable="false">4:3</string>
     <string id="_16R9" translatable="false">16:9</string>
+    <string id="_9R16" translatable="false">9:16</string>
 
 </strings>

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -11,11 +11,11 @@
     <string id="Sport">Sport</string>
     <string id="Eco">Eco</string>
     <string id="Manually">Manually edit\ncam settings</string>
-    <string id="EditP7">Edit presets</string>
+    <string id="SaveP7">Save current\n settings as preset</string>
 
     <!-- Menus -->
     <string id="Settings">Settings</string>
-    <string id="Presets">Edit Preset</string>
+    <string id="Presets">Choose preset</string>
     
     <!-- Settings -->
     <string id="Framerate">Framerate</string>
@@ -44,8 +44,8 @@
     <!-- Resolutions -->
     <string id="_5K" translatable="false">5.3K</string>
     <string id="_4K" translatable="false">4K</string>
-    <string id="_3K" translatable="false">2.7K</string>
-    <string id="_2K" translatable="false">1080p</string>
+    <string id="_2K7" translatable="false">2.7K</string>
+    <string id="_1080" translatable="false">1080p</string>
 
     <!-- Aspect Ratios -->
     <string id="_8R7" translatable="false">8:7</string>

--- a/source/components/GoProCamera.mc
+++ b/source/components/GoProCamera.mc
@@ -2,9 +2,11 @@ import Toybox.Lang;
 
 class GoProCamera extends GoProSettings {
     private var states as Array<Number>?;
+    private var availableSettings as Array<Array<Number>>?;
 
-    private var progress = 0 as Number;
-    private var connected = false as Boolean;
+    private var progress as Number = 0;
+    private var connected as Boolean = false;
+
 
     public function initialize() {
         GoProSettings.initialize();
@@ -26,6 +28,15 @@ class GoProCamera extends GoProSettings {
         if (states[RECORDING]==null) {states[RECORDING] = 0;}
         if (regionChanged) {MainResources.loadRegionLabels();}
         WatchUi.requestUpdate();
+    }
+
+    public function syncAvailableSettings(_availableSettings as Array<Array<Number>>) {
+        availableSettings = _availableSettings;
+        WatchUi.requestUpdate();
+    }
+
+    public function getAvailableSettings(id as Number) as Array<Number> {
+        return availableSettings[id];
     }
 
     public function isRecording() {

--- a/source/components/GoProPreset.mc
+++ b/source/components/GoProPreset.mc
@@ -21,17 +21,13 @@ class GoProPreset extends GoProSettings {
             settings = [
                 [_5K, _16R9, _LINEARLOCK, _24],
                 [_4K, _8R7, _LARGE, _60],
-                [_2K, _16R9, _LINEAR, _30]
+                [_1080, _16R9, _LINEAR, _30]
             ][_id];
         } 
     }
 
     public function save() {
+        settings = cam.getSettings();
         Application.Storage.setValue(id, settings);
-    }
-
-
-    public function getSettings() as Array<Number> {
-        return settings;
     }
 }

--- a/source/components/GoProPreset.mc
+++ b/source/components/GoProPreset.mc
@@ -19,7 +19,7 @@ class GoProPreset extends GoProSettings {
         if (settings == null or settings == [0]) {
             // Default presets defined below
             settings = [
-                [_5K, _16R9, _LINEARLOCK, _24],
+                [_5K3, _16R9, _LINEARLOCK, _24],
                 [_4K, _8R7, _LARGE, _60],
                 [_1080, _16R9, _LINEAR, _30]
             ][_id];

--- a/source/components/GoProSettings.mc
+++ b/source/components/GoProSettings.mc
@@ -4,103 +4,28 @@ import Toybox.Lang;
 
 class GoProSettings {
     protected var settings as Array<Number>;
-    
-    public static const resolutionList = [_5K, _4K, _3K, _2K];
-    public static const ratioList = [_8R7, _4R3, _16R9];
-    public static const lensList = [_HYPERVIEW, _SUPERVIEW, _LARGE, _LINEAR, _LINEARLOCK];
-    public static var framerateList = [_240, _120, _60, _30, _24];
 
     function initialize() {
-        settings = [_5K, _8R7, _LARGE, _30];
+        settings = [];
     }
 
     public function getSetting(id as Number) as Number {
         return settings[id];
     }
 
+    public function getSettings() as Array<Number> {
+        return settings;
+    }
+
     public function setSetting(id as Number, value as Number) {
         settings[id] = value;
-
-        var possibleValues;
-        id++;
-        while (id<N_SETTINGS) {
-            possibleValues = possibleSettings(id); 
-            if (!MainUtils.isValueInList(settings[id], possibleValues)) {
-                settings[id] = possibleValues[0];
-            }
-            id++;
-        }
     }
-
-    // TODO: replace with available settings request to camera
-    public function possibleSettings(id) as Array<Number>{ // for GoPro HERO 11 Black Mini
-        switch (id) {
-            case RESOLUTION:
-            return resolutionList;
-
-            case RATIO:
-            switch(settings[RESOLUTION]) {
-                case _5K:
-                case _4K:
-                    return ratioList;
-                case _3K:
-                    return ratioList.slice(1,3);
-                default: // 1080p
-                    return ratioList.slice(2,3);
-            }
-
-            case LENS:
-            switch(settings[RATIO]) {
-                case _8R7:
-                    return lensList.slice(2,3);
-                case _4R3:
-                    return lensList.slice(2,5);
-                default: // 16:9
-                    if(settings[RESOLUTION]==_3K or settings[RESOLUTION]==_2K) {
-                        return lensList.slice(1,5);
-                    } else {
-                        return lensList;
-                    }
-            }
-
-            case FRAMERATE:
-            switch(settings[RESOLUTION]) {
-                case _5K:
-                    if (settings[RATIO]==_8R7) {
-                        return framerateList.slice(3,4);
-                    } else if (settings[LENS]==_HYPERVIEW or settings[RATIO]==_4R3) {
-                        return framerateList.slice(3,5);
-                    } else {
-                        return framerateList.slice(2,4);
-                    }
-                case _4K:
-                    if (settings[RATIO]==_8R7 or settings[LENS]==_HYPERVIEW) {
-                        return framerateList.slice(2,3);
-                    } else if (settings[RATIO]==_4R3) {
-                        return framerateList.slice(2,5);
-                    } else {
-                        return framerateList.slice(1,5);
-                    }
-                case _3K:
-                    if (settings[RATIO]==_4R3 or settings[LENS]==_SUPERVIEW) {
-                        return framerateList.slice(1,3);
-                    } else {
-                        return framerateList.slice(0,3);
-                    }
-                default: // 1080p
-                    if (settings[LENS]==_SUPERVIEW) {
-                        return framerateList.slice(1,5);
-                    } else {
-                        return framerateList;
-                    }
-            }
-            default:
-                throw new Exception();
-        }
-    }
-
 
     public function getDescription() as String {
+        if (settings.size() != 4) {
+            return "...";
+        }
+        // System.println(settings);
         var frLabel = MainResources.settingLabels[FRAMERATE][settings[FRAMERATE]];
         return MainResources.settingLabels[RESOLUTION][settings[RESOLUTION]] \
             + "@" + frLabel.substring(0, frLabel.length()-4) + " " \

--- a/source/components/MainApp.mc
+++ b/source/components/MainApp.mc
@@ -58,6 +58,7 @@ class GoProRemoteApp extends Application.AppBase {
             if (PopUpView.currentView) { PopUpView.currentView.popOut(); }
             WatchUi.pushView(view, delegate, slide);
             nViewLayers++;
+            System.println("view_stack_size: " + nViewLayers.toString());
         }
     }
 
@@ -67,6 +68,7 @@ class GoProRemoteApp extends Application.AppBase {
             else {
                 WatchUi.popView(slide);
                 nViewLayers--;
+                System.println("view_stack_size: " + nViewLayers.toString());
             }
         }
     }

--- a/source/components/MainResources.mc
+++ b/source/components/MainResources.mc
@@ -47,6 +47,7 @@ enum Menus {
 
 // Settings enums
 enum Resolutions {
+    _5K3,
     _5K,
     _4K,
     _2K7,
@@ -57,7 +58,8 @@ enum Resolutions {
 enum Ratios {
     _8R7,
     _4R3,
-    _16R9
+    _16R9,
+    _9R16
 }
 
 enum Lenses {
@@ -65,7 +67,8 @@ enum Lenses {
     _SUPERVIEW,
     _LARGE,
     _LINEAR,
-    _LINEARLOCK
+    _LINEARLOCK,
+    _NARROW
 }
 
 enum Framerate {
@@ -162,21 +165,24 @@ class MainResources {
     static public function loadSettingLabels() as Void {
         settingLabels = [
             [
+                WatchUi.loadResource(Rez.Strings._5K3),
                 WatchUi.loadResource(Rez.Strings._5K),
                 WatchUi.loadResource(Rez.Strings._4K),
                 WatchUi.loadResource(Rez.Strings._2K7),
-                "",
+                WatchUi.loadResource(Rez.Strings._1440),
                 WatchUi.loadResource(Rez.Strings._1080)
             ], [
                 WatchUi.loadResource(Rez.Strings._8R7),
                 WatchUi.loadResource(Rez.Strings._4R3),
-                WatchUi.loadResource(Rez.Strings._16R9)
+                WatchUi.loadResource(Rez.Strings._16R9),
+                WatchUi.loadResource(Rez.Strings._9R16)
             ], [
                 WatchUi.loadResource(Rez.Strings._HYPERVIEW),
                 WatchUi.loadResource(Rez.Strings._SUPERVIEW),
                 WatchUi.loadResource(Rez.Strings._LARGE),
                 WatchUi.loadResource(Rez.Strings._LINEAR),
-                WatchUi.loadResource(Rez.Strings._LINEARLOCK)
+                WatchUi.loadResource(Rez.Strings._LINEARLOCK),
+                WatchUi.loadResource(Rez.Strings._NARROW)
             ], null
         ];
         loadRegionLabels();

--- a/source/components/MainResources.mc
+++ b/source/components/MainResources.mc
@@ -13,7 +13,7 @@ enum Editables {
     PSET2,
     PSET3,
     CAM,
-    EDITP7
+    SAVEP7
 }
 
 const N_SETTINGS = 4;
@@ -49,8 +49,9 @@ enum Menus {
 enum Resolutions {
     _5K,
     _4K,
-    _3K,
-    _2K
+    _2K7,
+    _1440,
+    _1080,
 }
 
 enum Ratios {
@@ -87,6 +88,8 @@ enum Communication {
     COM_PUSH_SETTINGS,
     COM_FETCH_STATES,
     COM_PUSH_STATES,
+    COM_FETCH_AVAILABLE,
+    COM_PUSH_AVAILABLE,
     COM_SHUTTER,
     COM_HIGHLIGHT,
     COM_LOCKED,
@@ -137,7 +140,7 @@ class MainResources {
                     WatchUi.loadResource(Rez.Strings.Sport),
                     WatchUi.loadResource(Rez.Strings.Eco),
                     WatchUi.loadResource(Rez.Strings.Manually),
-                    WatchUi.loadResource(Rez.Strings.EditP7)
+                    WatchUi.loadResource(Rez.Strings.SaveP7)
                 ];
             } else if (id == UI_SETTINGEDIT) {
                 labels[id] = [
@@ -161,8 +164,9 @@ class MainResources {
             [
                 WatchUi.loadResource(Rez.Strings._5K),
                 WatchUi.loadResource(Rez.Strings._4K),
-                WatchUi.loadResource(Rez.Strings._3K),
-                WatchUi.loadResource(Rez.Strings._2K)
+                WatchUi.loadResource(Rez.Strings._2K7),
+                "",
+                WatchUi.loadResource(Rez.Strings._1080)
             ], [
                 WatchUi.loadResource(Rez.Strings._8R7),
                 WatchUi.loadResource(Rez.Strings._4R3),
@@ -218,7 +222,7 @@ class MainResources {
                     WatchUi.loadResource(Rez.Drawables.Sport),  //PSET2
                     WatchUi.loadResource(Rez.Drawables.Eco),    //PSET3
                     WatchUi.loadResource(Rez.Drawables.Camera), //CAM
-                    WatchUi.loadResource(Rez.Drawables.Edit)    //EDITP7
+                    WatchUi.loadResource(Rez.Drawables.Edit)    //SAVEP7
                 ];
             } else if (id == UI_SETTINGEDIT) {
                 icons[id] = [

--- a/source/components/MobileDevice.mc
+++ b/source/components/MobileDevice.mc
@@ -42,7 +42,7 @@ class MobileDevice {
 
     public function onReceive(message as Communications.PhoneAppMessage) {
         System.println("received: " + message.data.toString());
-        var data = message.data as Array<Number or Array<Number>>;
+        var data = message.data as Array<Number or Array<Number or Array<Number>>>;
         switch (data[0]) {
             case COM_CONNECT:
                 // Ouverture connexion M>T>G>T>M
@@ -72,6 +72,11 @@ class MobileDevice {
             case COM_FETCH_STATES:
                 if (data[1]) {
                     cam.syncStates(data[1]);
+                }
+                break;
+            case COM_FETCH_AVAILABLE:
+                if (data[1]) {
+                    cam.syncAvailableSettings(data[1]);
                 }
                 break;
             case COM_PROGRESS:

--- a/source/interface/ConnectView.mc
+++ b/source/interface/ConnectView.mc
@@ -50,7 +50,7 @@ class GoProConnectDelegate extends WatchUi.BehaviorDelegate {
     public function onSelect() {
         mobile.connect();
         mobile.send([COM_CONNECT, 0]);
-        WatchUi.pushView(new PopUpView(MainResources.labels[UI_CONNECT][CONNECTING], POP_INFO), new PopUpDelegate(), WatchUi.SLIDE_BLINK);
+        GoProRemoteApp.pushView(new PopUpView(MainResources.labels[UI_CONNECT][CONNECTING], POP_INFO), new PopUpDelegate(), WatchUi.SLIDE_BLINK, false);
         return true;
     }
 }

--- a/source/interface/RemoteView.mc
+++ b/source/interface/RemoteView.mc
@@ -41,7 +41,7 @@ class RemoteDelegate extends WatchUi.BehaviorDelegate {
     }
 
     public function onMenu() {
-        GoProRemoteApp.pushView(new SettingsMenu(SettingsMenu.SM_MENU, -1, null), new SettingsMenuDelegate(SettingsMenu.SM_MENU, null), WatchUi.SLIDE_UP, false);
+        GoProRemoteApp.pushView(new SettingsMenu(SettingsMenu.SM_MENU, -1), new SettingsMenuDelegate(SettingsMenu.SM_MENU), WatchUi.SLIDE_UP, false);
         return true;
     }
 

--- a/source/interface/SettingEdit.mc
+++ b/source/interface/SettingEdit.mc
@@ -4,12 +4,12 @@ import Toybox.WatchUi;
 
 
 class SettingEditMenu extends WatchUi.CustomMenu {
-    public function initialize(setting as Number, gp as GoProSettings) {
+    public function initialize(setting as Number) {
         CustomMenu.initialize((70*kMult).toNumber(), Graphics.COLOR_BLACK, {:title=> new $.CustomMenuTitle(MainResources.labels[UI_SETTINGEDIT][setting])});
         var items;
         var selected;
-        items = gp.possibleSettings(setting);
-        selected = gp.getSetting(setting);
+        items = cam.getAvailableSettings(setting);
+        selected = cam.getSetting(setting);
         for (var i=0; i<items.size(); i++) {
             CustomMenu.addItem(new SettingEditItem(setting, items[i], selected));
         }
@@ -50,22 +50,20 @@ class SettingEditItem extends WatchUi.CustomMenuItem {
 
 class SettingEditDelegate extends WatchUi.Menu2InputDelegate {
     private var setting;
-    private var gp;
 
-    public function initialize(_setting as Number, _gp as GoProSettings) {
+    public function initialize(_setting as Number) {
         setting = _setting;
-        gp = _gp;
         Menu2InputDelegate.initialize();
     }
 
     public function onSelect(item) {
-        gp.setSetting(setting, item.getId());
+        cam.setSetting(setting, item.getId() as Number);
         (item as SettingEditItem).select();
         WatchUi.requestUpdate();
     }
 
     public function onBack() as Void {
-        MainResources.loadIcons(UI_SETTINGEDIT);
+        cam.save();
         GoProRemoteApp.popView(WatchUi.SLIDE_RIGHT);
     }
 

--- a/source/interface/SettingsMenu.mc
+++ b/source/interface/SettingsMenu.mc
@@ -27,7 +27,7 @@ class SettingsMenu extends WatchUi.CustomMenu {
 
             title = MainResources.labels[UI_MENUS][SETTINGS];
         } else {
-            title = cam.getDescription();
+            title = MainResources.labels[UI_MENUS][PRESETS];
         }
 
         CustomMenu.initialize((80*kMult).toNumber(), Graphics.COLOR_BLACK, {:title=> new CustomMenuTitle(title)});
@@ -110,6 +110,8 @@ class SettingsMenuDelegate extends WatchUi.Menu2InputDelegate {
                 GoProRemoteApp.pushView(new SettingsMenu(SettingsMenu.SM_PSETS, -1), new SettingsMenuDelegate(SettingsMenu.SM_PSETS), WatchUi.SLIDE_LEFT, false);
             } else if (menuType == SettingsMenu.SM_PSETS) {
                 (item as SettingsMenuItem).getPreset().save();
+                // Pop two views to remove old preset from menu memory
+                GoProRemoteApp.popView(WatchUi.SLIDE_IMMEDIATE);
                 GoProRemoteApp.popView(WatchUi.SLIDE_DOWN);
             } else {
                 cam.setPreset((item as SettingsMenuItem).getPreset());

--- a/source/interface/SettingsMenu.mc
+++ b/source/interface/SettingsMenu.mc
@@ -11,16 +11,13 @@ class SettingsMenu extends WatchUi.CustomMenu {
         SM_EDIT
     }
 
-    public function initialize(menuType as SettingsMenuType, presetId as Number, gp as GoProPreset?) {
+    public function initialize(menuType as SettingsMenuType, presetId as Number) {
         var title;
         if (menuType == SM_EDIT) {
             MainResources.loadIcons(UI_SETTINGEDIT);
             MainResources.loadLabels(UI_SETTINGEDIT);
 
             title = "GoPro";
-            if (presetId<3) {
-                title=MainResources.labels[UI_SETTINGSMENU][presetId];
-            }
         } else if (menuType == SM_MENU) {
             // MainResources.freeIcons(UI_HILIGHT);
             // MainResources.freeIcons(UI_MENUS);
@@ -30,18 +27,18 @@ class SettingsMenu extends WatchUi.CustomMenu {
 
             title = MainResources.labels[UI_MENUS][SETTINGS];
         } else {
-            title = MainResources.labels[UI_MENUS][PRESETS];
+            title = cam.getDescription();
         }
 
         CustomMenu.initialize((80*kMult).toNumber(), Graphics.COLOR_BLACK, {:title=> new CustomMenuTitle(title)});
         
         if (menuType == SM_EDIT) {
             for (var id=0; id<N_SETTINGS; id++) { // id => settingId
-                CustomMenu.addItem(new SettingsMenuItem(presetId as Editables, id as Settings, gp));
+                CustomMenu.addItem(new SettingsMenuItem(-1, id));
             }
         } else {
             for (var id=0; id < (menuType==SM_PSETS ? 3 : 5); id++) { // id => presetId
-                CustomMenu.addItem(new SettingsMenuItem(id as Editables, -1 as Settings, null)); // i => enum Editables
+                CustomMenu.addItem(new SettingsMenuItem(id, -1)); // i => enum Editables
             }
         }
     }
@@ -52,17 +49,16 @@ class SettingsMenuItem extends WatchUi.CustomMenuItem {
     private var settingId as Settings;
     private var gp as GoProPreset?;
 
-    public function initialize(pId as Editables, sId as Settings, _gp as GoProPreset?) {
+    public function initialize(pId, sId) {
         presetId = pId;
         settingId = sId;
         var itemId;
         if (sId != -1) {
             itemId = sId;
-            gp = _gp;
+            gp = cam;
         } else {
             itemId = pId;
             if (pId < 3) {gp = new GoProPreset(pId);}
-            else if (pId == 3) {gp = cam;}
         }
         CustomMenuItem.initialize(itemId, {});
     }
@@ -95,11 +91,9 @@ class SettingsMenuItem extends WatchUi.CustomMenuItem {
 
 class SettingsMenuDelegate extends WatchUi.Menu2InputDelegate {
     var menuType as SettingsMenu.SettingsMenuType;
-    protected var gp as GoProPreset?;
 
-    public function initialize(_menuType as SettingsMenu.SettingsMenuType, _gp as GoProPreset?) {
+    public function initialize(_menuType as SettingsMenu.SettingsMenuType) {
         menuType = _menuType;
-        gp = _gp;
         Menu2InputDelegate.initialize();
     }
 
@@ -108,23 +102,23 @@ class SettingsMenuDelegate extends WatchUi.Menu2InputDelegate {
         // WARNING: popping view unloads mandatory icons and loads unnecessary ones in simulator while the problem doesn't appear on device and lower (<4.1.7 beta) SDK versions
         // NOTE: issue unseen with SDK 6.3.0 and 7.3.0
         if (menuType == SettingsMenu.SM_EDIT) {
-            GoProRemoteApp.pushView(new SettingEditMenu(id, gp), new SettingEditDelegate(id, gp), WatchUi.SLIDE_UP, false);
+            GoProRemoteApp.pushView(new SettingEditMenu(id), new SettingEditDelegate(id), WatchUi.SLIDE_UP, false);
         } else {
-            if (id == CAM or menuType == SettingsMenu.SM_PSETS) {
-                GoProRemoteApp.pushView(new SettingsMenu(SettingsMenu.SM_EDIT, id, (item as SettingsMenuItem).getPreset()), new SettingsMenuDelegate(SettingsMenu.SM_EDIT, (item as SettingsMenuItem).getPreset()), WatchUi.SLIDE_LEFT, true);
-            } else if (id == EDITP7) {
-                GoProRemoteApp.pushView(new SettingsMenu(SettingsMenu.SM_PSETS, -1, null), new SettingsMenuDelegate(SettingsMenu.SM_PSETS, null), WatchUi.SLIDE_LEFT, false);
-            } else {
+            if (id == CAM) {
+                GoProRemoteApp.pushView(new SettingsMenu(SettingsMenu.SM_EDIT, id), new SettingsMenuDelegate(SettingsMenu.SM_EDIT), WatchUi.SLIDE_LEFT, true);
+            } else if (id == SAVEP7) {
+                GoProRemoteApp.pushView(new SettingsMenu(SettingsMenu.SM_PSETS, -1), new SettingsMenuDelegate(SettingsMenu.SM_PSETS), WatchUi.SLIDE_LEFT, false);
+            } else if (menuType == SettingsMenu.SM_PSETS) {
+                (item as SettingsMenuItem).getPreset().save();
                 GoProRemoteApp.popView(WatchUi.SLIDE_DOWN);
+            } else {
                 cam.setPreset((item as SettingsMenuItem).getPreset());
+                GoProRemoteApp.popView(WatchUi.SLIDE_DOWN);
             }
         }
-
-
     }
 
     public function onBack() as Void {
-        if (gp != null) {gp.save();}
         GoProRemoteApp.popView(WatchUi.SLIDE_DOWN);
     }
 


### PR DESCRIPTION
Enables compatibility with most GoPros (except HERO13) by detecting the camera's currently available settings and sending them to the watch.
Therefore, preset editing has been replaced by saving current settings as a preset because the camera's capabilities for one resolution can't be known (without hardcoding every combination for every model) without changing it.